### PR TITLE
Fixes behavior on hangups and aborts

### DIFF
--- a/lib/request_set.js
+++ b/lib/request_set.js
@@ -18,10 +18,10 @@ function RequestSet(pool, options, callback) {
 	this.attemptsLeft = attemptsFu(options, pool)
 	this.attempts = this.attemptsLeft
 
-	this.maxHangups = options.maxHangups || 2
+	this.maxHangups = options.maxHangups || pool.options.maxRetries;
 	this.hangups = 0
 
-	this.maxAborts = options.maxAborts || 2
+	this.maxAborts = options.maxAborts || pool.options.maxRetries;
 	this.aborts = 0
 
 	if (!options.retryDelay && options.retryDelay !== 0) {
@@ -52,7 +52,7 @@ function handleResponse(err, response, body) {
 		if (err.reason === "socket hang up") { this.hangups++ }
 		else if (err.reason === "aborted") { this.aborts++ }
 
-		if (this.attemptsLeft > 0 && this.hangups < 2 && this.aborts < 2) {
+		if (this.attemptsLeft > 0 && this.hangups < this.maxHangups && this.aborts < this.maxAborts) {
 			this.pool.onRetry(err)
 			if (delay > 0) {
 				setTimeout(this.doRequest.bind(this), delay)

--- a/test/requestset_test.js
+++ b/test/requestset_test.js
@@ -108,14 +108,14 @@ describe("RequestSet", function () {
 			})
 		})
 
-		it("retries hangups once then fails", function (done) {
+		it("retries hangups identically to other requests then fails", function (done) {
 			var p = {
 				i: 0,
 				options: { maxRetries: 5 },
 				get_node: function () { return this.nodes[this.i++]},
 				onRetry: function () {},
 				length: 3,
-				nodes: [{ request: hangup_request }, { request: hangup_request }, { request: succeeding_request }]
+				nodes: [{ request: hangup_request }, { request: hangup_request }, { request: hangup_request }, { request: hangup_request }, { request: hangup_request }, { request: succeeding_request }]
 			}
 			RequestSet.request(p, {}, function (err, res, body) {
 				assert.equal(err.reason, "socket hang up")
@@ -139,14 +139,14 @@ describe("RequestSet", function () {
 			})
 		})
 
-		it("retries aborts once then fails", function (done) {
+		it("retries aborts identically to other requests then fails", function (done) {
 			var p = {
 				i: 0,
 				options: { maxRetries: 5 },
 				get_node: function () { return this.nodes[this.i++]},
 				onRetry: function () {},
 				length: 3,
-				nodes: [{ request: aborted_request }, { request: aborted_request }, { request: succeeding_request }]
+				nodes: [{ request: aborted_request }, { request: aborted_request }, { request: aborted_request }, { request: aborted_request}, { request: aborted_request}, { request: aborted_request} ]
 			}
 			RequestSet.request(p, {}, function (err, res, body) {
 				assert.equal(err.reason, "aborted")


### PR DESCRIPTION
The existing behavior on hangups and aborts disregarded the parameters
passed in via options, and failed at a number smaller than maxRetries.
This is counter intuitive, undocumented, and not modifiable from the
external API.

This pull request defaults maxHangups and maxAborts to maxRetries and
changes the underlying code to actually use those values rather than
hard coded values.

This caused issues for us when one node was responding very slowly. It was timing out, and
because of the way that poolee picks nodes, it was sometimes getting selected again. The failure
would then get through to the client.
