### PR TITLE
changes to request and get_node

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -233,6 +233,7 @@ module.exports = function (inherits, EventEmitter, Pinger, EndpointError) {
 
 		this.setPending()
 		this.requests[req.id] = req
+		return req
 	}
 
 	Endpoint.prototype.setHealthy = function (newState) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -68,7 +68,7 @@ module.exports = function (inherits, EventEmitter, Endpoint, RequestSet) {
 			secure ? https : http,
 			[host + ':' + port]
 		)
-		p.request(options, data, cb)
+		return p.request(options, data, cb)
 	}
 
 	// Bound handlers
@@ -144,7 +144,7 @@ module.exports = function (inherits, EventEmitter, Endpoint, RequestSet) {
 		options.stream = (options.stream === undefined) ? callback.length === 2 : options.stream
 
 		var started = Date.now()
-		RequestSet.request(this, options, function (err, res, body) {
+		return RequestSet.request(this, options, function (err, res, body) {
 			options.success = !err
 			options.reused = res && res.socket && (res.socket._requestCount || 1) > 1
 			self.emit('timing', Date.now() - started, options)

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -185,31 +185,27 @@ module.exports = function (inherits, EventEmitter, Endpoint, RequestSet) {
 
 	Pool.prototype.get_node = function () {
 		var len = this.nodes.length
-		var h = []
-		var sum = 0
 		var totalPending = 0
 		var r = Math.floor(Math.random() * len)
+		var lowestPending = this.maxPending
+		var lowestPedingNode = this.nodes[(r + 1) % len];
 		for (var i = 0; i < len; i++) {
 			r = (r + 1) % len
 			var node = this.nodes[r]
 			if (node.ready()) {
 				return node //fast path
 			}
-			else if (node.healthy) {
-				h.push(node)
-				sum += node.pending
+			if (node.healthy && node.pending < lowestPending) {
+				lowestPending = node.pending
+				lowestPedingNode = node
 			}
 			totalPending += node.pending
 		}
 		if (totalPending >= this.maxPending) {
 			return Endpoint.overloaded()
 		}
-		var avg = sum / h.length
-		while (h.length) {
-			var node = h.pop()
-			if (node.pending <= avg) {
-				return node
-			}
+		if (lowestPending < this.maxPending) {
+			return lowestPedingNode
 		}
 		return Endpoint.unhealthy()
 	}

--- a/lib/request_set.js
+++ b/lib/request_set.js
@@ -81,12 +81,12 @@ function handleResponse(err, response, body) {
 // callback: function (err, response, body) {}
 RequestSet.request = function (pool, options, callback) {
 	var set = new RequestSet(pool, options, callback)
-	set.doRequest()
+	return set.doRequest()
 }
 
 RequestSet.prototype.doRequest = function () {
 	var node = this.pool.get_node()
-	node.request(this.options, handleResponse.bind(this))
+	return node.request(this.options, handleResponse.bind(this))
 }
 
 module.exports = RequestSet


### PR DESCRIPTION
Two changes:

1. pool.request and Pool.request now return the http.request object. This is good for both test and reuse purpose. I noticed that pool.put, pool.post and pool.del all return pool.request, but pool.request returns nothing. 

2. pool.get_node now returns the node with lowest number of pending requests. 